### PR TITLE
Vector search

### DIFF
--- a/common/bootstrap/SetUp.php
+++ b/common/bootstrap/SetUp.php
@@ -23,6 +23,7 @@ use App\services\Manticore\IndexService;
 use App\Indexer\Service\IndexFromDB\Handler;
 use App\dispatchers\SimpleAppEventDispatcher;
 use App\Indexer\Service\QuestionIndexService;
+use App\Library\manticore\services\VectorizerService;
 use Symfony\Component\Mailer\MailerInterface;
 use App\repositories\Question\QuestionRepository;
 use Symfony\Component\EventDispatcher\EventDispatcher;
@@ -102,6 +103,11 @@ class SetUp implements BootstrapInterface
             new Client($app->params['manticore']),
             $app->params['searchResults']['pageSize'],
         ]);
+
+        $container->setSingleton(VectorizerService::class, [], [
+            $app->params['vectorizer']['apiUrl'],
+            $app->params['vectorizer']['apiKey'],
+        ]);        
 
         require __DIR__ . '/twig.php';
     }

--- a/common/config/params.php
+++ b/common/config/params.php
@@ -63,4 +63,9 @@ return [
         'common' => getenv('MANTICORE_DB_NAME_COMMON') ?: 'library2025',
         'concept' => getenv('MANTICORE_DB_NAME_COMMON') . '_concept' ?: 'library_concept',
     ],
+
+    'vectorizer' => [
+        'apiUrl' =>  getenv('MANTICORE_HOST').':'.(int)getenv('MANTICORE_PORT'),
+        'apiKey' => getenv('MANTICORE_API_KEY'),
+    ],
 ];

--- a/frontend/config/urlManager.php
+++ b/frontend/config/urlManager.php
@@ -22,6 +22,7 @@ return [
         'library' => 'library/index',
         'library/search' => 'library/search',
         'library/context' => 'site/context',
+        'library/paragraph/<id:\d+>' => 'library/paragraph',
 
         '<_c:[\w\-]+>' => '<_c>/index',
         '<_c:[\w\-]+>/<id:\d+>' => '<_c>/view',

--- a/frontend/controllers/LibraryController.php
+++ b/frontend/controllers/LibraryController.php
@@ -107,6 +107,15 @@ class LibraryController extends Controller
         $errorQueryMessage = '';
 
         $form->load(Yii::$app->request->queryParams);
+        // Сброс paragraphId при новом текстовом запросе
+        if ($form->query && $form->paragraphId) {
+            $form->paragraphId = null;
+        }
+        // Обработка запроса по ID параграфа
+        // var_dump($form->paragraphId); die();
+        if ($form->paragraphId && $form->matching === 'vector') {
+            $form->query = ''; // Очищаем текстовый запрос
+        }
         if ($form->isEmpty()) {
             return $this->redirect('index');
         }

--- a/frontend/controllers/LibraryController.php
+++ b/frontend/controllers/LibraryController.php
@@ -6,17 +6,18 @@ namespace frontend\controllers;
 
 use Yii;
 use Exception;
-use src\Library\manticore\services\AuthorService;
+use yii\web\Response;
 use yii\web\Controller;
 use yii\filters\VerbFilter;
 use yii\filters\AccessControl;
 use src\Search\forms\SearchForm;
+use yii\web\NotFoundHttpException;
+use src\Library\manticore\services\TitleService;
+use src\Library\manticore\services\AuthorService;
 use src\Library\manticore\services\ContextService;
 use src\Library\manticore\services\ManticoreService;
 use src\Search\Http\Action\V1\SearchSettings\ToggleAction;
 use src\Library\manticore\services\EmptySearchRequestExceptions;
-use src\Library\manticore\services\TitleService;
-use yii\web\Response;
 
 class LibraryController extends Controller
 {
@@ -141,6 +142,19 @@ class LibraryController extends Controller
             'aggs' => $aggs ?? [],
             'model' => $form,
             'errorQueryMessage' => $errorQueryMessage,
+        ]);
+    }
+
+    public function actionParagraph($id)
+    {
+        try {
+            $quoteResult = $this->contextService->handle($id);
+            // $model = $this->service->findParagraphById($id);
+        } catch (\DomainException $e) {
+            throw new NotFoundHttpException('Запрашиваемый параграф не найден');
+        };
+        return $this->render('paragraph', [
+            'quoteResult' => $quoteResult,
         ]);
     }
 

--- a/frontend/views/library/paragraph.php
+++ b/frontend/views/library/paragraph.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+use src\Search\helpers\SearchResultHelper;
+use src\Library\manticore\models\Paragraph;
+use src\Search\models\ContextPDO;
+
+/** @var yii\web\View $this */
+/** @var ContextPDO $quoteResult */
+
+/** @var string $bookName */
+$bookName = $quoteResult->bookName;
+$paragraph = $quoteResult->paragraph;
+$this->title = $bookName;
+
+?>
+<div class="container-fluid quote-results">
+    <div class="row">
+        <div class="col-md-12">
+            <div class="card pt-3 my-3">
+                <div class="card-body p-0">
+                    <div class="px-xl-5 px-lg-5 px-md-5 px-sm-3 paragraph">
+                        <div id="<?= $paragraph->chunk; ?>" data-entity-id="<?= $paragraph->id; ?>">
+                            <div class="card-body">
+
+                                <div class="paragraph-text">
+                                    <?= SearchResultHelper::highlightFieldContent($paragraph, 'content', 'markdown', false); ?>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="d-flex justify-content-start book-name pt-4">
+                            <div><strong><i><?= $bookName; ?></i></strong></div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>

--- a/frontend/views/library/search.php
+++ b/frontend/views/library/search.php
@@ -50,11 +50,11 @@ echo Html::endForm();
       <div class="alert alert-info mt-3">
         <div class="d-flex justify-content-between align-items-center">
           <span>
-            Показаны параграфы, похожие на <?=Html::a('#'.$model->paragraphId, ['library/paragraph', 'id' => $model->paragraphId], ['target' => '_blank']); ?>
+            Показаны параграфы, похожие на <?= Html::a($model->paragraphId, ['library/paragraph', 'id' => $model->paragraphId], ['target' => '_blank']); ?>
           </span>
-          <?= Html::a('Вернуться к обычному поиску', ['library/search'], [
-            'class' => 'btn btn-sm btn-outline-primary'
-          ]) ?>
+          <!-- <?= Html::a('Вернуться к обычному поиску', ['library/search'], [
+                  'class' => 'btn btn-sm btn-outline-primary'
+                ]) ?> -->
         </div>
       </div>
     <?php endif; ?>
@@ -181,22 +181,23 @@ echo Html::endForm();
                             'data-bs-toggle' => 'tooltip',
                             'data-bs-placement' => 'bottom',
                             'data-bs-title' => 'Похожие параграфы',
-                            'style' => 'text-decoration: none;'
+                            'style' => 'text-decoration: none;',
+                            'target' => '_blank'
                           ]
                         ); ?>
                         <?php
-                        // Добавим кнопку для сброса поиска похожих
-                        if ($model->paragraphId) {
-                          echo Html::a('Очистить поиск похожих', ['library/search'], [
-                            'class' => 'btn btn-sm btn-outline-secondary ms-2'
-                          ]);
-                        } ?>
-                      </div>
-                      <div class="text-muted small" style="line-height: 1.2; padding-top: 2px">
-                        Символов: <?= $paragraph->char_count ?>, слов: <?= $paragraph->word_count ?>
+                        // кнопка для сброса поиска похожих
+                        // if ($model->paragraphId) {
+                        //   echo Html::a('Очистить поиск похожих', ['library/search'], [
+                        //     'class' => 'btn btn-sm btn-outline-secondary ms-2'
+                        //   ]);
+                        // } 
+                        ?>
                       </div>
                     </div>
-
+                    <div class="text-muted small d-none d-md-block" style="line-height: 1.2; padding-top: 2px">
+                      Симв: <?= $paragraph->char_count ?>, токенов: <?= $paragraph->word_count ?>, пар-ф: <?= $paragraph->chunk ?>, кач: <?= $paragraph->ocr_quality ?>, язык: <?= $paragraph->language ?>
+                    </div>
                     <!-- Правый блок с источником -->
                     <div class="source d-flex align-items-center gap-2">
                       <span data-bs-toggle="tooltip" data-bs-placement="left"
@@ -211,6 +212,9 @@ echo Html::endForm();
                         data-source="<?= Html::encode($paragraph->source) ?>"></i>
                     </div>
                   </div>
+                  <!-- <div class="text-muted small d-md-none d-sm-block" style="line-height: 1.2; padding-top: 2px">
+                    Симв: <?= $paragraph->char_count ?>, ток: <?= $paragraph->word_count ?>, пар: <?= $paragraph->chunk ?>, кач: <?= $paragraph->ocr_quality ?>, яз: <?= $paragraph->language ?>
+                  </div> -->
                 </div>
               </div>
             <?php endforeach; ?>

--- a/frontend/views/library/search.php
+++ b/frontend/views/library/search.php
@@ -1,5 +1,6 @@
 <?php
 
+use yii\helpers\Url;
 use yii\bootstrap5\Html;
 use yii\data\Pagination;
 use yii\bootstrap5\LinkPager;
@@ -44,6 +45,19 @@ echo Html::endForm();
 <div class="site-index">
   <?= $this->render('_search-panel', ['model' => $model]); ?>
   <div class="container-fluid search-results">
+
+    <?php if ($model->paragraphId): ?>
+      <div class="alert alert-info mt-3">
+        <div class="d-flex justify-content-between align-items-center">
+          <span>
+            Показаны параграфы, похожие на <?=Html::a('#'.$model->paragraphId, ['library/paragraph', 'id' => $model->paragraphId], ['target' => '_blank']); ?>
+          </span>
+          <?= Html::a('Вернуться к обычному поиску', ['library/search'], [
+            'class' => 'btn btn-sm btn-outline-primary'
+          ]) ?>
+        </div>
+      </div>
+    <?php endif; ?>
 
     <?php if (!$results): ?>
 
@@ -150,6 +164,33 @@ echo Html::endForm();
                         <i id="share-<?= $paragraph->id ?>" class="bi bi-share" style="font-size: 1.2rem;  margin-top: -8px"
                           data-bs-toggle="tooltip" data-bs-placement="bottom"
                           data-bs-title="Поделиться"></i>
+                        <!-- Ссылка на реузльтаы поиска похожих параграфов -->
+                        <?php
+                        $params = Yii::$app->request->queryParams;
+                        $params['search']['paragraphId'] = $paragraph->id;
+                        $params['search']['matching'] = 'vector';
+                        unset($params['search']['query']); // Очищаем текстовый запрос
+                        unset($params['page']); // Сбрасываем пагинацию
+                        $similarUrl = Url::to(array_merge(['library/search'], $params));
+                        ?>
+                        <?= Html::a(
+                          '<i class="bi bi-intersect" style="font-size: 1.2rem;  margin-top: -8px"></i> Похожие',
+                          $similarUrl,
+                          [
+                            'id' => "similar-{$paragraph->id}",
+                            'data-bs-toggle' => 'tooltip',
+                            'data-bs-placement' => 'bottom',
+                            'data-bs-title' => 'Похожие параграфы',
+                            'style' => 'text-decoration: none;'
+                          ]
+                        ); ?>
+                        <?php
+                        // Добавим кнопку для сброса поиска похожих
+                        if ($model->paragraphId) {
+                          echo Html::a('Очистить поиск похожих', ['library/search'], [
+                            'class' => 'btn btn-sm btn-outline-secondary ms-2'
+                          ]);
+                        } ?>
                       </div>
                       <div class="text-muted small" style="line-height: 1.2; padding-top: 2px">
                         Символов: <?= $paragraph->char_count ?>, слов: <?= $paragraph->word_count ?>

--- a/src/Library/manticore/models/Paragraph.php
+++ b/src/Library/manticore/models/Paragraph.php
@@ -15,18 +15,35 @@ class Paragraph extends Model
     public string $title;
     public string $title_attr;
     public string $content;
-    public string $chunk;
-    public string $char_count;
-    public string $word_count;
+    public int $chunk;
+    public int $char_count;
+    public int $word_count;
     public string $language;
-    public string $ocr_quality;
+    public float $ocr_quality;
     public array $highlight;
     public string $source_uuid;
     public string $source;
     public int $datetime;
     public int $created_at;
     public int $updated_at;
-    private int $id;
+    public int $id = 0;
+
+
+   public static function build(array $hitData): self
+    {
+        $model = new static();
+        
+        $attributes = [];
+        foreach ($hitData as $key => $value) {
+            $newKey = str_replace('library2025.', '', $key);
+            $attributes[$newKey] = $value;
+        }
+        
+        // Присваиваем атрибуты модели
+        $model->setAttributes($attributes, false);
+        
+        return $model;
+    }
 
     public static function create(
         string $text,
@@ -37,8 +54,8 @@ class Paragraph extends Model
         $paragraph = new static();
 
         $paragraph->content = $text;
-        $paragraph->chunk = $position;
-        $paragraph->cahr_count = $length;
+        $paragraph->chunk = (int)$position;
+        $paragraph->char_count = (int)$length;
         $paragraph->highlight = $highlight;
 
         return $paragraph;

--- a/src/Library/manticore/repositories/ParagraphDataProvider.php
+++ b/src/Library/manticore/repositories/ParagraphDataProvider.php
@@ -64,10 +64,14 @@ class ParagraphDataProvider extends BaseDataProvider
             }
 
             for ($count = 0; $count < $limit; ++$count) {
-                $model = new Paragraph($data->current()->getData());
-                $model->setId((int)$data->current()->getId());
+                $hit = $data->current();
+                //$model = new Paragraph($data->current()->getData());
+                $model = Paragraph::build($hit->getData());
+                if ($model->getId() === 0) {                
+                    $model->setId((int)$hit->getId());
+                }
                 try {
-                    $model->highlight = $data->current()->getHighlight();
+                    $model->highlight = $hit->getHighlight();
                 } catch (\Exception $e) {
                     $model->highlight = [];
                 }

--- a/src/Library/manticore/repositories/ParagraphRepository.php
+++ b/src/Library/manticore/repositories/ParagraphRepository.php
@@ -270,7 +270,7 @@ class ParagraphRepository
         $content_vector = [];
         $query = "SELECT content_vector from library2025_content_vectors where content_id=$paragraphId";
         try {
-            $response = $this->client->sql($query);           
+            $response = $this->client->sql($query);
             // var_dump($response['hits']['hits'] ); die();
             $hits = $response['hits']['hits'] ?? [];
             $source = $hits[0]['_source'] ?? [];
@@ -286,7 +286,7 @@ class ParagraphRepository
         } catch (Exception $e) {
             // Обработка ошибок запроса
             error_log("Manticore query failed: " . $e->getMessage());
-           throw new DomainException("Failed to execute Manticore query: " . $e->getMessage());
+            throw new DomainException("Failed to execute Manticore query: " . $e->getMessage());
         }
 
         $this->search->reset();
@@ -295,7 +295,7 @@ class ParagraphRepository
         // var_dump($_id);
         $joinQuery = new JoinQuery('left', 'library2025', 'content_id', 'id');
         $this->search->join($joinQuery, true)
-            ->knn('content_vector', $content_vector, 100); 
+            ->knn('content_vector', $content_vector, 100);
 
         // Применяем фильтры
         if ($form->genre !== '') {
@@ -523,17 +523,17 @@ class ParagraphRepository
 
     /**
      * Возвращает paragraph по id
-     * @param string $uuid
+     * @param int $uuid
      * @return Paragraph
      */
-    public function getByParagraphID(string $id): Paragraph
+    public function getByParagraphID(int $id): Paragraph
     {
         $table =  new Table($this->client, 'library2025');
         /** @var \Manticoresearch\ResultHit **/
         $hit = $table->getDocumentById($id);
 
         if (!$hit) {
-            throw new \DomainException('Параграф с не найден');
+            throw new DomainException('Параграф не найден');
         }
 
         $par = new Paragraph($hit->getData());

--- a/src/Library/manticore/repositories/ParagraphRepository.php
+++ b/src/Library/manticore/repositories/ParagraphRepository.php
@@ -4,20 +4,22 @@ declare(strict_types=1);
 
 namespace src\Library\manticore\repositories;
 
+use DomainException;
 use Yii;
+use Exception;
 use Manticoresearch\Table;
 use Manticoresearch\Client;
 use Manticoresearch\Search;
 use Manticoresearch\Query\In;
 use Manticoresearch\Response;
 use yii\caching\TagDependency;
+use PhpParser\Node\Expr\Match_;
 use src\Search\forms\SearchForm;
 use Manticoresearch\Query\Equals;
 use Manticoresearch\Query\BoolQuery;
 use Manticoresearch\Query\JoinQuery;
-use Manticoresearch\Query\MatchQuery;
-use PhpParser\Node\Expr\Match_;
 use src\Search\helpers\SearchHelper;
+use Manticoresearch\Query\MatchQuery;
 use src\Library\manticore\models\Paragraph;
 
 
@@ -229,7 +231,7 @@ class ParagraphRepository
         $this->search->setSource(['library2025.*']);
         $joinQuery = new JoinQuery('left', 'library2025', 'content_id', 'id');
         $this->search->join($joinQuery, true)
-            ->knn('content_vector', $vector, 100);            
+            ->knn('content_vector', $vector, 100);
 
 
         if ($form->genre !== '') {
@@ -253,13 +255,77 @@ class ParagraphRepository
         }
         // $this->search->filter(new BoolQuery()->must(new MatchQuery('content', $form->query)));
 
-            $limit = 200;
-            $sortField = 'count(*)';
-            $sortDirection = 'desc';
+        $limit = 200;
+        $sortField = 'count(*)';
+        $sortDirection = 'desc';
         // Подготавливаем фасеты
         $this->search->facet('library2025.genre', 'genre_group', $limit, $sortField, $sortDirection);
         $this->search->facet('library2025.author', 'author_group', $limit, $sortField, $sortDirection);
         $this->search->facet('library2025.title', 'title_group', $limit, $sortField, $sortDirection);
+        return $this->search;
+    }
+
+    public function findBySimilarParagraphId(int $paragraphId, SearchForm $form): Search
+    {
+        $content_vector = [];
+        $query = "SELECT content_vector from library2025_content_vectors where content_id=$paragraphId";
+        try {
+            $response = $this->client->sql($query);           
+            // var_dump($response['hits']['hits'] ); die();
+            $hits = $response['hits']['hits'] ?? [];
+            $source = $hits[0]['_source'] ?? [];
+
+            $content_vector = empty($hits) ? null : $source['content_vector'];
+
+            // Для отладки:
+            if ($content_vector === null) {
+                error_log("Document not found for paragraphId: $paragraphId");
+            }
+
+            // var_dump($_id); // или используйте значение
+        } catch (Exception $e) {
+            // Обработка ошибок запроса
+            error_log("Manticore query failed: " . $e->getMessage());
+           throw new DomainException("Failed to execute Manticore query: " . $e->getMessage());
+        }
+
+        $this->search->reset();
+        $this->search->setTable('library2025_content_vectors');
+        $this->search->setSource(['library2025.*']);
+        // var_dump($_id);
+        $joinQuery = new JoinQuery('left', 'library2025', 'content_id', 'id');
+        $this->search->join($joinQuery, true)
+            ->knn('content_vector', $content_vector, 100); 
+
+        // Применяем фильтры
+        if ($form->genre !== '') {
+            $this->search->filter(
+                'library2025.genre',
+                'in',
+                $form->genre === SearchHelper::EMPTY_GENRE ? "" : $form->genre
+            );
+        }
+
+        if ($form->author !== '') {
+            $this->search->filter(
+                'library2025.author',
+                'in',
+                $form->author === SearchHelper::EMPTY_AUTHOR ? "" : $form->author
+            );
+        }
+
+        if ($form->title !== '') {
+            $this->search->filter('library2025.title', 'in', $form->title);
+        }
+
+        // Фасеты
+        $limit = 200;
+        $sortField = 'count(*)';
+        $sortDirection = 'desc';
+        $this->search->facet('library2025.genre', 'genre_group', $limit, $sortField, $sortDirection);
+        $this->search->facet('library2025.author', 'author_group', $limit, $sortField, $sortDirection);
+        $this->search->facet('library2025.title', 'title_group', $limit, $sortField, $sortDirection);
+
         return $this->search;
     }
 

--- a/src/Library/manticore/services/ContextService.php
+++ b/src/Library/manticore/services/ContextService.php
@@ -21,7 +21,7 @@ class ContextService
     public function handle(string $id): ContextPDO
     {
         try {
-            $paragraph = $this->paragraphRepository->getByParagraphID($id);
+            $paragraph = $this->paragraphRepository->getByParagraphID((int)$id);
         } catch (\Exception $e) {
             throw new \DomainException($e->getMessage());
         }

--- a/src/Library/manticore/services/ManticoreService.php
+++ b/src/Library/manticore/services/ManticoreService.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace src\Library\manticore\services;
 
+use App\Library\manticore\services\VectorizerService;
 use src\Library\manticore\repositories\AuthorRepository;
 use src\Library\manticore\repositories\TitleRepository;
 use Yii;
@@ -18,15 +19,18 @@ class ManticoreService
     private ParagraphRepository $paragraphRepository;
     private AuthorRepository $authorRepository;
     private TitleRepository $titleRepository;
+    private VectorizerService $vectorizer;
 
     public function __construct(
         ParagraphRepository $questionRepository,
         AuthorRepository $authorRepository,
-        TitleRepository $titleRepository
+        TitleRepository $titleRepository,
+        VectorizerService $vectorizer
     ) {
         $this->paragraphRepository = $questionRepository;
         $this->authorRepository = $authorRepository;
         $this->titleRepository = $titleRepository;
+        $this->vectorizer = $vectorizer;
     }
 
     /**
@@ -35,6 +39,8 @@ class ManticoreService
      */
     public function search(SearchForm $form): ParagraphDataProvider
     {
+        $vector = $this->vectorizer->vectorize($form->query);
+        //var_dump($vector);
         $results = match ($form->matching) {
             'query_string' => $this->paragraphRepository->findByQueryStringNew($form),
             'match_phrase' => $this->paragraphRepository->findByMatchPhrase($form),

--- a/src/Library/manticore/services/ManticoreService.php
+++ b/src/Library/manticore/services/ManticoreService.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace src\Library\manticore\services;
 
 use App\Library\manticore\services\VectorizerService;
+use src\Library\manticore\models\Paragraph;
 use src\Library\manticore\repositories\AuthorRepository;
 use src\Library\manticore\repositories\TitleRepository;
 use Yii;
@@ -56,7 +57,7 @@ class ManticoreService
                 'context' => $this->paragraphRepository->findByContext($form),
             };
         }
-// var_dump($results->get()->getResponse()->getResponse());
+        // var_dump($results->get()->getResponse()->getResponse());
         $responseData = $results->get()->getResponse()->getResponse();
         // var_dump($responseData);
         // Определяем параметры пагинации

--- a/src/Library/manticore/services/ManticoreService.php
+++ b/src/Library/manticore/services/ManticoreService.php
@@ -38,17 +38,25 @@ class ManticoreService
      * @return ParagraphDataProvider
      */
     public function search(SearchForm $form): ParagraphDataProvider
-    {            
-        $results = match ($form->matching) {
-            'query_string' => $this->paragraphRepository->findByQueryStringNew($form),
-            'match_phrase' => $this->paragraphRepository->findByMatchPhrase($form),
-            'match' => $this->paragraphRepository->findByQueryStringMatch($form),
-            'vector' => $this->paragraphRepository->findByVector($form, $this->vectorizer->vectorize($form->query)),
-            'context' => $this->paragraphRepository->findByContext($form),
-
-        };
-
-
+    {
+        // Обработка поиска по похожим параграфам
+        if ($form->paragraphId && $form->matching === 'vector') {
+            $results = $this->paragraphRepository->findBySimilarParagraphId(
+                (int)$form->paragraphId,
+                $form
+            );
+        }
+        // Обычный поиск
+        else {
+            $results = match ($form->matching) {
+                'query_string' => $this->paragraphRepository->findByQueryStringNew($form),
+                'match_phrase' => $this->paragraphRepository->findByMatchPhrase($form),
+                'match' => $this->paragraphRepository->findByQueryStringMatch($form),
+                'vector' => $this->paragraphRepository->findByVector($form, $this->vectorizer->vectorize($form->query)),
+                'context' => $this->paragraphRepository->findByContext($form),
+            };
+        }
+// var_dump($results->get()->getResponse()->getResponse());
         $responseData = $results->get()->getResponse()->getResponse();
         // var_dump($responseData);
         // Определяем параметры пагинации

--- a/src/Library/manticore/services/ManticoreService.php
+++ b/src/Library/manticore/services/ManticoreService.php
@@ -38,18 +38,19 @@ class ManticoreService
      * @return ParagraphDataProvider
      */
     public function search(SearchForm $form): ParagraphDataProvider
-    {
-        $vector = $this->vectorizer->vectorize($form->query);
-        //var_dump($vector);
+    {            
         $results = match ($form->matching) {
             'query_string' => $this->paragraphRepository->findByQueryStringNew($form),
             'match_phrase' => $this->paragraphRepository->findByMatchPhrase($form),
             'match' => $this->paragraphRepository->findByQueryStringMatch($form),
+            'vector' => $this->paragraphRepository->findByVector($form, $this->vectorizer->vectorize($form->query)),
             'context' => $this->paragraphRepository->findByContext($form),
+
         };
 
 
         $responseData = $results->get()->getResponse()->getResponse();
+        // var_dump($responseData);
         // Определяем параметры пагинации
         $pagination = $form->matching === 'context' ? [
             'pageSize' => Yii::$app->params['context']['pageSize'],
@@ -63,16 +64,16 @@ class ManticoreService
                 'query' => $results,
                 'pagination' => $pagination,
                 'sort' => [
-                    'defaultOrder' => [
-                        '_score' => SORT_DESC,
-                        'chunk' => SORT_ASC,
-                        'id' => SORT_ASC,
-                    ],
-                    'attributes' => [
-                        '_score',
-                        'chunk',
-                        'id',
-                    ]
+                    // 'defaultOrder' => [
+                    //     '_score' => SORT_DESC,
+                    //     'chunk' => SORT_ASC,
+                    //     'id' => SORT_ASC,
+                    // ],
+                    // 'attributes' => [
+                    //     '_score',
+                    //     'chunk',
+                    //     'id',
+                    // ]
                 ],
                 'responseData' => $responseData
             ]

--- a/src/Library/manticore/services/VectorizerService.php
+++ b/src/Library/manticore/services/VectorizerService.php
@@ -43,6 +43,8 @@ class VectorizerService
             ],
             CURLOPT_POSTFIELDS => $payload,
             CURLOPT_FAILONERROR => false, // Самостоятельно обрабатываем коды 4xx/5xx
+            CURLOPT_TIMEOUT => 5, // Максимум 5 секунд
+            CURLOPT_CONNECTTIMEOUT => 2, // Таймаут соединения
         ]);
 
         // Выполнение запроса

--- a/src/Library/manticore/services/VectorizerService.php
+++ b/src/Library/manticore/services/VectorizerService.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Library\manticore\services;
+
+use RuntimeException;
+use JsonException;
+
+class VectorizerService
+{
+    private string $apiUrl;
+    private string $apiKey;
+
+    // Конструктор для инициализации параметров
+    public function __construct(string $apiUrl, string $apiKey)
+    {
+        $this->apiUrl = rtrim($apiUrl, '/');
+        $this->apiKey = $apiKey;
+    }
+
+    /**
+     * Векторизация текста через внешний API.
+     *
+     * @param string $text Исходный текст
+     * @return array Вектор чисел (float)
+     * @throws RuntimeException При ошибках сети или API
+     */
+    public function vectorize(string $text): array
+    {
+        // Формируем данные для запроса
+        $payload = json_encode(['text' => $text], JSON_THROW_ON_ERROR);
+        
+        // Инициализация cURL
+        $ch = curl_init("{$this->apiUrl}/vectorize");
+        curl_setopt_array($ch, [
+            CURLOPT_RETURNTRANSFER => true,
+            CURLOPT_POST => true,
+            CURLOPT_HTTPHEADER => [
+                "X-API-Key: {$this->apiKey}",
+                "Content-Type: application/json",
+                "Content-Length: " . strlen($payload)
+            ],
+            CURLOPT_POSTFIELDS => $payload,
+            CURLOPT_FAILONERROR => false, // Самостоятельно обрабатываем коды 4xx/5xx
+        ]);
+
+        // Выполнение запроса
+        $response = curl_exec($ch);
+        $httpCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+        $error = curl_error($ch);
+        curl_close($ch);
+
+        // Обработка ошибок сети
+        if ($response === false) {
+            throw new RuntimeException("cURL error: " . $error);
+        }
+
+        // Обработка HTTP-ошибок
+        if ($httpCode !== 200) {
+            throw new RuntimeException("API error. HTTP code: {$httpCode}. Response: " . $response);
+        }
+
+        // Декодирование JSON
+        try {
+            $result = json_decode($response, true, 512, JSON_THROW_ON_ERROR);
+        } catch (JsonException $e) {
+            throw new RuntimeException("JSON decode error: " . $e->getMessage());
+        }
+
+        // Проверка наличия вектора в ответе
+        if (!isset($result['vector']) || !is_array($result['vector'])) {
+            throw new RuntimeException("Invalid API response: 'vector' field missing");
+        }
+
+        return $result['vector'];
+    }
+}

--- a/src/Search/forms/SearchForm.php
+++ b/src/Search/forms/SearchForm.php
@@ -41,6 +41,7 @@ class SearchForm extends Model
             'query_string' => 'Обычный поиск',
             'match_phrase' => 'Точное соответствие',
             'match' => 'Любое слово',
+            'vector' => 'Векторное соответствие',
         ];
     }
 

--- a/src/Search/forms/SearchForm.php
+++ b/src/Search/forms/SearchForm.php
@@ -10,6 +10,7 @@ use src\Search\helpers\SearchHelper;
 class SearchForm extends Model
 {
     public string $query = '';
+    public $paragraphId = null;
     public string $genre = '';
     public string $author = '';
     public string $title = '';
@@ -19,12 +20,13 @@ class SearchForm extends Model
     public bool $genreInlineView = false;
     // Включает нечёткий поиск 
     public bool $fuzzy = false;
-    public string $matching = 'query_string';
+    public string $matching = 'query_string';    
 
     public function rules(): array
     {
         return [
             ['query', 'string'],
+             ['paragraphId', 'integer', 'min' => 1],
             ['genre', 'string'],
             ['author', 'string'],
             ['title', 'string'],
@@ -61,6 +63,6 @@ class SearchForm extends Model
 
     public function isEmpty(): bool
     {
-        return ($this->query === '' && ($this->genre === '' && $this->author === '' & $this->title === ''));
+        return (($this->query === '' && ($this->genre === '' && $this->author === '' & $this->title === '')) && $this->paragraphId === null);
     }
 }


### PR DESCRIPTION
Добавлен режим поиска: Векторное соответствие
Добавлен функционал поиска похожего параграфа, ссылка располагается под каждым параграфом в левом нижнем блоке: Похожие.

В общем пока не понятно, это как дополнение к обычному поиску, иногда дает интересные результаты по полному слову, но чаще если в поиске одно слово, то результаты не очень, В этом случае, показался полезным сценарий, когда ищем одно слово обычным поиском, и позже ищем похожие параграфы.
Фразы уже более дают интересные результаты. Предложения, и целые отрывки, еще интереснее.

Легок можно найти дубликаты, которые не совсем дубли а целые блоки в разных книгах у авторов, так делает ВП СССР, так делаю и другие авторы. 

Показалось интересным, что поиск похожих параграфов в стихах выдает параграфы со стихами, математика.
Интересно, что можно найти книги с шахматными партиями, когда увидел первый раз не понял,  подумал, баг, странный шифр, а это обозначения шахмат. Такие параграфы близки.  В общем еще требуется оценить полезность этого всего, но кажется она есть.

Если полезность будет подтверждена, то можно улучшить результаты, доработать токенизатор, в этой версии векторов цифры и числа не в словаре, полагаю с продвинутыми правилами токенизации, что то из того что я делал еще зимой как упражнение с python можно применить и улучшить результат.

Сейчас для итогового вектора параграфа я использовал метод [SIF (Smooth Inverse Frequency)](https://github.com/terratensor/manticore-vectorizer/blob/main/VECTORIZATION_METHODS.md#2-sif-smooth-inverse-frequency)

Нужно будет реализовать [TF-IDF взвешивание ](https://github.com/terratensor/manticore-vectorizer/blob/main/VECTORIZATION_METHODS.md#3-tf-idf-%D0%B2%D0%B7%D0%B2%D0%B5%D1%88%D0%B8%D0%B2%D0%B0%D0%BD%D0%B8%D0%B5-%D0%B2-%D1%80%D0%B0%D0%B7%D1%80%D0%B0%D0%B1%D0%BE%D1%82%D0%BA%D0%B5) и сравнить результаты.

Технически реализация получилась не очень, но уже после этой реализации стало ясно как улучшить, в том числе изучил код мантикоре в их репозитории, поиск по гитхабу. Основной момент, который требуется решить это обновление векторов во всей базе 38 ил параграфов. В текущая реализации это занимает около 8 часов, появились мысли как это улучшить. Сейчас таблица векторов это отдельная таблица и она соединяется через join с основной, но в этом методе оказалось, что есть некоторые ограничения, не все функции в объединении работаю с KNN.  Т.е. пока кажется лучшим решением поле с векторами хранить сразу в параграфе а не отдельной таблицей, будет гибче и можно будет организовать типа гибридный поиск. 
Таблица с векторами занимает 93 Гб (векторы размерности 300)
Таблица с параграфами занимает 204 Гб

upd https://github.com/terratensor/library/issues/3